### PR TITLE
URL Cleanup

### DIFF
--- a/README
+++ b/README
@@ -16,7 +16,7 @@ The Maven Android Plugin makes use of the Android SDK command line tools to comp
 Install the Android SDK
 -----------------------
 Download the correct version of the Android SDK for your operating system from the Android web site:
-http://developer.android.com/sdk/index.html
+https://developer.android.com/sdk/index.html
 
 Unzip the archive and place it in a location of your choosing. For example on a Mac, you may want to place it in the root of your user directory.  See the download web site for additional installation details.
 
@@ -42,7 +42,7 @@ Note: you may want to simply install all the available updates, but be aware it 
 
 Configure an Android Virtual Device
 -----------------------------------
-http://developer.android.com/guide/developing/devices/index.html
+https://developer.android.com/guide/developing/devices/index.html
 Open the Android SDK and AVD Manager window:
 $ android
 Select Virtual devices in the left hand column and click the New button
@@ -84,7 +84,7 @@ A Note about URLs
 -----------------
 Depending on where you deploy the server app, you may need to modify the Android client configuration to point to the correct URL. If you are running from an Android AVD (emulator) and connecting to a local Greenhouse instance, the client will access the localhost via the 10.0.2.2 proxy address. Localhost on an Android device refers to itself, and not the host computer where the emulator is running.  If you deploy the Android client to an actual device, then you will need to modify the URL so the device can communicate to the server.  To modify the URL, edit the 'filters/dev.properties' file in the greenhouse-android directory, and change the base.url property to reflect the location of the Greenhouse server.
 
-base.url=http://10.0.2.2:8080/greenhouse/
+base.url=https://10.0.2.2:8080/greenhouse/
 
 Once the url is modified, simply repeat the steps to build and run the client app with the new settings.
 

--- a/filters/dev.properties
+++ b/filters/dev.properties
@@ -2,4 +2,4 @@ client.id=e9fbccdae98d5696
 client.secret=9fa283e1eca2d4e8
 connection.repository.encryption.password=password
 connection.repository.encryption.salt=5c0744940b5c369b
-base.url=http://10.0.2.2:8080/greenhouse/
+base.url=https://10.0.2.2:8080/greenhouse/

--- a/src/com/springsource/greenhouse/events/EventsActivityGroup.java
+++ b/src/com/springsource/greenhouse/events/EventsActivityGroup.java
@@ -26,7 +26,7 @@ import android.view.Window;
 
 /*
  * Good example from Henrik Larsen Toft on how to set up a Nested TabActivity  
- * http://blog.henriklarsentoft.com/2010/07/android-tabactivity-nested-activities/
+ * https://blog.henriklarsentoft.com/2010/07/android-tabactivity-nested-activities/
  */
 
 public class EventsActivityGroup extends ActivityGroup {


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://10.0.2.2:8080/greenhouse/ (ConnectTimeoutException) with 2 occurrences migrated to:  
  https://10.0.2.2:8080/greenhouse/ ([https](https://10.0.2.2:8080/greenhouse/) result ConnectTimeoutException).
* [ ] http://blog.henriklarsentoft.com/2010/07/android-tabactivity-nested-activities/ (UnknownHostException) with 1 occurrences migrated to:  
  https://blog.henriklarsentoft.com/2010/07/android-tabactivity-nested-activities/ ([https](https://blog.henriklarsentoft.com/2010/07/android-tabactivity-nested-activities/) result UnknownHostException).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://developer.android.com/guide/developing/devices/index.html with 1 occurrences migrated to:  
  https://developer.android.com/guide/developing/devices/index.html ([https](https://developer.android.com/guide/developing/devices/index.html) result 301).
* [ ] http://developer.android.com/sdk/index.html with 1 occurrences migrated to:  
  https://developer.android.com/sdk/index.html ([https](https://developer.android.com/sdk/index.html) result 301).

# Ignored
These URLs were intentionally ignored.

* http://localhost:8080/greenhouse-1.0.0.BUILD-SNAPSHOT with 1 occurrences